### PR TITLE
feat: Integración de Owners y mejoras en la gestión de mediciones

### DIFF
--- a/commons/src/main/java/com/cyver/plant/commons/dto/PlantDto.java
+++ b/commons/src/main/java/com/cyver/plant/commons/dto/PlantDto.java
@@ -3,7 +3,6 @@ package com.cyver.plant.commons.dto;
 import java.io.Serial;
 import java.io.Serializable;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import com.cyver.plant.commons.annotations.Default;

--- a/commons/src/main/java/com/cyver/plant/commons/entities/Owner.java
+++ b/commons/src/main/java/com/cyver/plant/commons/entities/Owner.java
@@ -1,0 +1,55 @@
+package com.cyver.plant.commons.entities;
+
+import java.util.List;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Table(name = "owner", indexes = @Index(name = "owner_auth0_sid_idx", columnList = "auth0_sid", unique = true))
+@AttributeOverride(name = "uuid", column = @Column(name = "owner_id"))
+public class Owner extends Audit {
+
+    @NonNull
+    @Column(nullable = false, updatable = false)
+    private String name;
+
+    @NonNull
+    @Column(nullable = false, updatable = false)
+    private String email;
+
+    @NonNull
+    @Column(nullable = false, updatable = false)
+    private String picture;
+
+    @NonNull
+    @Column(nullable = false, updatable = false)
+    private String nickname;
+
+    @Column(name = "auth0_sid", nullable = false, updatable = false)
+    private String auth0Sid;
+
+    @ToString.Exclude
+    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Plant> plants;
+
+}

--- a/commons/src/main/java/com/cyver/plant/commons/entities/Plant.java
+++ b/commons/src/main/java/com/cyver/plant/commons/entities/Plant.java
@@ -48,8 +48,9 @@ public final class Plant extends Audit {
     private PlantLocation plantLocation;
 
     @NonNull
-    @Column(nullable = false, updatable = false)
-    private UUID owner;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "owner", nullable = false, updatable = false)
+    private Owner owner;
 
     @NonNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/consumer/src/main/java/com/cyver/plant/consumer/service/impl/PlantServiceImpl.java
+++ b/consumer/src/main/java/com/cyver/plant/consumer/service/impl/PlantServiceImpl.java
@@ -2,41 +2,45 @@ package com.cyver.plant.consumer.service.impl;
 
 import java.util.UUID;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.cyver.plant.commons.avro.PlantAvro;
+import com.cyver.plant.commons.entities.Owner;
 import com.cyver.plant.commons.entities.Plant;
 import com.cyver.plant.commons.entities.PlantType;
 import com.cyver.plant.consumer.service.PlantService;
+import com.cyver.plant.database.OwnerRepository;
 import com.cyver.plant.database.PlantRepository;
 import com.cyver.plant.database.PlantTypeRepository;
 import com.cyver.plant.utilities.map.MapUtilComponent;
 
+import lombok.AllArgsConstructor;
+
 @Service
+@AllArgsConstructor(onConstructor_ = { @Autowired })
 public class PlantServiceImpl implements PlantService {
 
     private final PlantRepository plantRepository;
 
     private final PlantTypeRepository plantTypeRepository;
 
-    private final MapUtilComponent mapUtilComponent;
+    private final OwnerRepository ownerRepository;
 
-    public PlantServiceImpl(final PlantRepository plantRepository, final PlantTypeRepository plantTypeRepository,
-            final MapUtilComponent mapUtilComponent) {
-        this.plantRepository = plantRepository;
-        this.plantTypeRepository = plantTypeRepository;
-        this.mapUtilComponent = mapUtilComponent;
-    }
+    private final MapUtilComponent mapUtilComponent;
 
     @Override
     public Plant creatIfNotExists(final PlantAvro plantAvro) {
         final UUID ownerUUID = UUID.fromString(plantAvro.getOwnerId());
-        return plantRepository.findPlantByNameAndOwner(plantAvro.getPlantName(), ownerUUID)
+        Owner owner = ownerRepository.findById(ownerUUID).orElseThrow(() -> new IllegalArgumentException("Owner not found"));
+        return plantRepository.findPlantByNameAndOwner(plantAvro.getPlantName(), owner)
                 .orElseGet(() -> createAndSavePlant(plantAvro));
     }
 
     private Plant createAndSavePlant(PlantAvro plantAvro) {
-        return plantRepository.save(mapUtilComponent.toEntity(plantAvro, findOrCreatePlantType(plantAvro)));
+        final UUID ownerUUID = UUID.fromString(plantAvro.getOwnerId());
+        Owner owner = ownerRepository.findById(ownerUUID).orElseThrow(() -> new IllegalArgumentException("Owner not found"));
+        return plantRepository.save(mapUtilComponent.toEntity(plantAvro, findOrCreatePlantType(plantAvro), owner));
     }
 
     private PlantType findOrCreatePlantType(final PlantAvro plantAvro) {

--- a/data/src/main/java/com/cyver/plant/data/service/PlantService.java
+++ b/data/src/main/java/com/cyver/plant/data/service/PlantService.java
@@ -1,12 +1,11 @@
 package com.cyver.plant.data.service;
 
 import java.util.List;
-import java.util.UUID;
 
 import com.cyver.plant.commons.dto.PlantDto;
 
 public interface PlantService {
 
-    List<PlantDto> getPlantsByOwner(UUID owner);
+    List<PlantDto> getPlantsByOwner(String auth0Sid);
 
 }

--- a/data/src/main/java/com/cyver/plant/data/service/impl/PlantServiceImpl.java
+++ b/data/src/main/java/com/cyver/plant/data/service/impl/PlantServiceImpl.java
@@ -7,7 +7,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.cyver.plant.commons.dto.PlantDto;
+import com.cyver.plant.commons.entities.Owner;
 import com.cyver.plant.data.service.PlantService;
+import com.cyver.plant.database.OwnerRepository;
 import com.cyver.plant.database.PlantRepository;
 import com.cyver.plant.utilities.stream.StreamUtilComponent;
 
@@ -19,10 +21,11 @@ public class PlantServiceImpl implements PlantService {
 
     private final PlantRepository plantRepository;
 
-    private final StreamUtilComponent streamUtilComponent;
+    private final OwnerRepository ownerRepository;
 
     @Override
-    public List<PlantDto> getPlantsByOwner(final UUID owner) {
-        return plantRepository.findPlantsByOwner(owner);
+    public List<PlantDto> getPlantsByOwner(final String auth0Sid) {
+        Owner owner = ownerRepository.findByAuth0Sid(auth0Sid).orElseThrow();
+        return plantRepository.findPlantsByOwner(owner.getUuid());
     }
 }

--- a/data/src/main/java/com/cyver/plant/data/web/rest/PlantResource.java
+++ b/data/src/main/java/com/cyver/plant/data/web/rest/PlantResource.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,9 +34,9 @@ public class PlantResource {
     private final EnvironmentalMeasurementService environmentalMeasurementService;
 
     @GetMapping(produces = { MediaType.APPLICATION_JSON_VALUE })
-    public ResponseEntity<List<PlantDto>> getPlantsByOwner(Principal principal) {
+    public ResponseEntity<List<PlantDto>> getPlantsByOwner(@AuthenticationPrincipal OAuth2User principal) {
         log.info("REST request to get plants by owner : {}", principal.getName());
-        return new ResponseEntity<>(plantService.getPlantsByOwner(UUID.fromString("f9312fe2-6d9f-45a7-a2d9-c9dbe34941bc")), HttpStatus.OK);
+        return new ResponseEntity<>(plantService.getPlantsByOwner(principal.getAttribute("sid")), HttpStatus.OK);
     }
 
     @GetMapping(path = "/{plantUuid}/environmental-measurement", produces = { MediaType.APPLICATION_JSON_VALUE })

--- a/database/src/main/java/com/cyver/plant/database/OwnerRepository.java
+++ b/database/src/main/java/com/cyver/plant/database/OwnerRepository.java
@@ -1,0 +1,14 @@
+package com.cyver.plant.database;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cyver.plant.commons.entities.Owner;
+
+public interface OwnerRepository extends JpaRepository<Owner, UUID> {
+
+    Optional<Owner> findByAuth0Sid(String auth0Sid);
+
+}

--- a/database/src/main/java/com/cyver/plant/database/PlantRepository.java
+++ b/database/src/main/java/com/cyver/plant/database/PlantRepository.java
@@ -9,11 +9,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.cyver.plant.commons.dto.PlantDto;
+import com.cyver.plant.commons.entities.Owner;
 import com.cyver.plant.commons.entities.Plant;
 
 public interface PlantRepository extends JpaRepository<Plant, UUID> {
 
-    Optional<Plant> findPlantByNameAndOwner(String name, UUID owner);
+    Optional<Plant> findPlantByNameAndOwner(String name, Owner owner);
 
     @Query(value = """
             SELECT \

--- a/producer/src/main/java/com/cyver/plant/producer/configuration/MaxmindConfiguration.java
+++ b/producer/src/main/java/com/cyver/plant/producer/configuration/MaxmindConfiguration.java
@@ -14,7 +14,7 @@ public class MaxmindConfiguration {
 
     @Bean
     public DatabaseReader maxmindDatabase() throws IOException {
-        InputStream is = new ClassPathResource("datos/FO.mmdb").getInputStream();
+        InputStream is = new ClassPathResource("datos/GeoLite2-City.mmdb").getInputStream();
         return new DatabaseReader.Builder(is).build();
     }
 

--- a/producer/src/main/java/com/cyver/plant/producer/configuration/UnirestConfiguration.java
+++ b/producer/src/main/java/com/cyver/plant/producer/configuration/UnirestConfiguration.java
@@ -1,5 +1,7 @@
 package com.cyver.plant.producer.configuration;
 
+import java.util.Objects;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,7 +30,7 @@ public class UnirestConfiguration {
             long startNanos = System.nanoTime();
             return (responseSummary, exception) -> log.info("path: {} status: {} time: {}",
                     requestSummary.getRawPath(),
-                    responseSummary.getStatus(),
+                    Objects.isNull(responseSummary) ? "N/A" : responseSummary.getStatus(),
                     System.nanoTime() - startNanos);
         });
         return unirest;

--- a/producer/src/main/java/com/cyver/plant/producer/service/NodeCommunicationService.java
+++ b/producer/src/main/java/com/cyver/plant/producer/service/NodeCommunicationService.java
@@ -1,10 +1,11 @@
 package com.cyver.plant.producer.service;
 
+import com.cyver.plant.commons.exceptions.NodeResponseFailedException;
 import com.cyver.plant.commons.node.NodeMeasurementResponse;
 import com.cyver.plant.producer.configuration.PlantProperties;
 
 public interface NodeCommunicationService {
 
-    NodeMeasurementResponse getMeasurement(PlantProperties.NodeConfiguration nodeConfiguration);
+    NodeMeasurementResponse getMeasurement(PlantProperties.NodeConfiguration nodeConfiguration) throws NodeResponseFailedException;
 
 }

--- a/producer/src/main/resources/application.yaml
+++ b/producer/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ spring:
       value-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
 
 plant:
-  cron: ${PLANT_CRON}
+  interval: ${PLANT_INTERVAL}
   user: ${PLANT_USER}
   topic: ${KAFKA_TOPIC}
   nodes:

--- a/utilities/src/main/java/com/cyver/plant/utilities/map/MapUtilComponent.java
+++ b/utilities/src/main/java/com/cyver/plant/utilities/map/MapUtilComponent.java
@@ -7,6 +7,7 @@ import com.cyver.plant.commons.avro.PlantAvro;
 import com.cyver.plant.commons.dto.EnvironmentalMeasurementDto;
 import com.cyver.plant.commons.dto.PlantDto;
 import com.cyver.plant.commons.entities.EnvironmentalMeasurement;
+import com.cyver.plant.commons.entities.Owner;
 import com.cyver.plant.commons.entities.Plant;
 import com.cyver.plant.commons.entities.PlantType;
 import com.cyver.plant.commons.node.NodeMeasurementResponse;
@@ -32,8 +33,8 @@ public class MapUtilComponent {
         return PlantMapper.INSTANCE.toDto(plant);
     }
 
-    public Plant toEntity(PlantAvro plantAvro, PlantType plantType) {
-        return PlantMapper.INSTANCE.toEntity(plantAvro, plantType);
+    public Plant toEntity(PlantAvro plantAvro, PlantType plantType, Owner owner) {
+        return PlantMapper.INSTANCE.toEntity(plantAvro, plantType, owner);
     }
 
 }

--- a/utilities/src/main/java/com/cyver/plant/utilities/map/PlantMapper.java
+++ b/utilities/src/main/java/com/cyver/plant/utilities/map/PlantMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.factory.Mappers;
 
 import com.cyver.plant.commons.avro.PlantAvro;
 import com.cyver.plant.commons.dto.PlantDto;
+import com.cyver.plant.commons.entities.Owner;
 import com.cyver.plant.commons.entities.Plant;
 import com.cyver.plant.commons.entities.PlantType;
 
@@ -20,12 +21,12 @@ interface PlantMapper {
     @Mapping(target = "type", source = "type.name")
     PlantDto toDto(Plant plant);
 
-    @Mapping(target = "owner", expression = "java(java.util.UUID.fromString(plantAvro.getOwnerId()))")
+    @Mapping(target = "owner", source = "owner")
     @Mapping(target = "environmentalMeasurements", expression = "java(java.util.Collections.emptyList())")
     @Mapping(target = "name", source = "plantAvro.plantName")
     @Mapping(target = "plantLocation", source = "plantAvro.plantLocation")
     @Mapping(target = "type", source = "plantType")
     @Mapping(target = "uuid", ignore = true)
-    Plant toEntity(PlantAvro plantAvro, PlantType plantType);
+    Plant toEntity(PlantAvro plantAvro, PlantType plantType, Owner owner);
 
 }


### PR DESCRIPTION
Se implementó un nuevo modelo de gestión de propietarios (`Owner`), reemplazando el manejo anterior con `UUID owner` en `Plant`, permitiendo una mejor autenticación y gestión de datos. Además, se añadieron mejoras en la estabilidad del productor, consumidor y base de datos. ¡CyverPlant ahora es más seguro, escalable y robusto! 🌱✨

---
### 🧩 **Cambios generales por módulo:**

#### 🌱 **Commons**
- Se creó la nueva **entidad `Owner`** para gestionar la información del propietario de cada planta.
- Se reemplazó el `UUID owner` en `Plant` por una **relación directa** con la entidad `Owner`, facilitando la integración con autenticación.
- Se ajustó `PlantDto` eliminando importaciones innecesarias (`LocalDateTime`).
- Se mejoraron los mapeos de entidades para soportar la nueva relación.

---
#### 🏭 **Consumer**
- Se modificó `PlantServiceImpl` para **validar la existencia de un `Owner`** antes de asociar una nueva planta.
- Se incorporó `OwnerRepository` al consumidor para manejar la búsqueda de propietarios.
- Se refactorizó el flujo de creación de plantas para soportar la autenticación con `auth0Sid`.

---
#### 📊 **Data**
- Se adaptó `PlantService` para recibir `auth0Sid` en lugar de `UUID` del propietario, alineándolo con la autenticación.
- Se creó un nuevo método en `OwnerRepository` para recuperar `Owner` mediante `auth0Sid`.
- Se actualizó `PlantResource` para extraer el **`sid` del usuario autenticado** directamente desde el token de autenticación (`OAuth2User`).
- Se añadieron consultas optimizadas en `PlantRepository` para manejar la búsqueda por propietario.

---
#### 🗃️ **Database**
- **Se creó `OwnerRepository`** con soporte para buscar propietarios usando `auth0Sid`, facilitando la autenticación en el sistema.
- Se modificó `PlantRepository` para **buscar plantas usando `Owner` en lugar de `UUID`**, manteniendo la consistencia de datos.

---
#### ⚙️ **Producer**
- **Corrección en la configuración de MaxMind**: Ahora el productor usa la base de datos `GeoLite2-City.mmdb` correctamente.
- Se agregó **manejo de excepciones en `NodeCommunicationService`** para capturar errores de `Unirest` y evitar fallos inesperados.
- Se ajustó la tarea `SendMeasurementToKafkaTask` para **manejar errores al recolectar mediciones**, evitando interrupciones en la transmisión de datos.
- Se cambió la configuración de `application.yaml`, **reemplazando `cron` por `interval`**, permitiendo definir la frecuencia de envío en minutos en lugar de expresiones cron.

---
#### 🔧 **Utilities**
- Se actualizaron `MapUtilComponent` y `PlantMapper` para reflejar la nueva relación con `Owner`, asegurando que los datos se mapeen correctamente.
- Se mejoró la conversión de `PlantAvro` a `Plant`, asegurando que **cada planta tenga su propietario registrado correctamente**.