### PR TITLE
Add dashboard statistics and plant list

### DIFF
--- a/frontend/src/app/view/dashboard/dashboard-statistics.component.html
+++ b/frontend/src/app/view/dashboard/dashboard-statistics.component.html
@@ -1,0 +1,6 @@
+<mat-card>
+  <mat-card-title>Estadísticas</mat-card-title>
+  <mat-card-content>
+    <p>Total de plantas: {{ plantCount }}</p>
+  </mat-card-content>
+</mat-card>

--- a/frontend/src/app/view/dashboard/dashboard-statistics.component.scss
+++ b/frontend/src/app/view/dashboard/dashboard-statistics.component.scss
@@ -1,0 +1,4 @@
+mat-card {
+  margin: 10px;
+  max-width: 300px;
+}

--- a/frontend/src/app/view/dashboard/dashboard-statistics.component.spec.ts
+++ b/frontend/src/app/view/dashboard/dashboard-statistics.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DashboardStatisticsComponent } from './dashboard-statistics.component';
+
+describe('DashboardStatisticsComponent', () => {
+  let component: DashboardStatisticsComponent;
+  let fixture: ComponentFixture<DashboardStatisticsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardStatisticsComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DashboardStatisticsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/view/dashboard/dashboard-statistics.component.ts
+++ b/frontend/src/app/view/dashboard/dashboard-statistics.component.ts
@@ -1,0 +1,13 @@
+import {Component, Input} from '@angular/core';
+import {MatCardModule} from '@angular/material/card';
+
+@Component({
+  selector: 'app-dashboard-statistics',
+  standalone: true,
+  imports: [MatCardModule],
+  templateUrl: './dashboard-statistics.component.html',
+  styleUrl: './dashboard-statistics.component.scss'
+})
+export class DashboardStatisticsComponent {
+  @Input() plantCount = 0;
+}

--- a/frontend/src/app/view/dashboard/dashboard.component.html
+++ b/frontend/src/app/view/dashboard/dashboard.component.html
@@ -1,1 +1,4 @@
-<p>dashboard works!</p>
+<div class="dashboard-container">
+  <app-dashboard-statistics [plantCount]="plants.length"></app-dashboard-statistics>
+  <app-plant-list [plants]="plants"></app-plant-list>
+</div>

--- a/frontend/src/app/view/dashboard/dashboard.component.scss
+++ b/frontend/src/app/view/dashboard/dashboard.component.scss
@@ -1,0 +1,5 @@
+.dashboard-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/frontend/src/app/view/dashboard/dashboard.component.ts
+++ b/frontend/src/app/view/dashboard/dashboard.component.ts
@@ -1,11 +1,22 @@
-import { Component } from '@angular/core';
+import {Component, inject, OnInit} from '@angular/core';
+import {PlantResourceService, PlantWithLastEnvironmentalMeasurement} from '../../client';
+import {PlantListComponent} from './plant-list.component';
+import {DashboardStatisticsComponent} from './dashboard-statistics.component';
 
 @Component({
   selector: 'app-dashboard',
-  imports: [],
+  standalone: true,
+  imports: [PlantListComponent, DashboardStatisticsComponent],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss'
 })
-export class DashboardComponent {
+export class DashboardComponent implements OnInit {
+  private readonly plantResourceService: PlantResourceService = inject(PlantResourceService);
+  plants: PlantWithLastEnvironmentalMeasurement[] = [];
 
+  ngOnInit(): void {
+    this.plantResourceService.getPlantsByOwner().subscribe(plants => {
+      this.plants = plants;
+    });
+  }
 }

--- a/frontend/src/app/view/dashboard/plant-list.component.html
+++ b/frontend/src/app/view/dashboard/plant-list.component.html
@@ -1,0 +1,26 @@
+<div class="container">
+  @if (plants.length > 0) {
+    @for (plant of plants; track plant.plantName) {
+      <mat-card>
+        <mat-card-header>
+          <mat-card-title>{{ plant.plantName | uppercase }} | {{ plant.typeName }}</mat-card-title>
+          <mat-card-subtitle>Ultima muestra: {{ plant.measuredAt | date:'medium' }}</mat-card-subtitle>
+        </mat-card-header>
+        <mat-divider></mat-divider>
+        <mat-card-footer>
+          <mat-chip-set>
+            <mat-chip>Temperature: {{ plant.temperature }} {{ plant.unit === "CELSIUS" ? '°C' : '°F' }}</mat-chip>
+            <mat-chip>Humedad: {{ plant.humidity }}%</mat-chip>
+            <mat-chip>Luz: {{ plant.light }}%</mat-chip>
+            <mat-chip>Humedad en substrato: {{ plant.soilMoisture }}%</mat-chip>
+          </mat-chip-set>
+        </mat-card-footer>
+        <mat-card-actions>
+          <button mat-button>Historial</button>
+        </mat-card-actions>
+      </mat-card>
+    }
+  } @else {
+    <p>No hay plantas registradas.</p>
+  }
+</div>

--- a/frontend/src/app/view/dashboard/plant-list.component.scss
+++ b/frontend/src/app/view/dashboard/plant-list.component.scss
@@ -1,0 +1,31 @@
+$card-margin: 10px;
+
+div.container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 0 20px;
+
+  mat-card {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    max-width: 400px;
+    max-height: 400px;
+    margin: $card-margin;
+    padding: 5px;
+
+    mat-card-header {
+      flex-shrink: 0;
+
+      mat-card-subtitle {
+        font-size: 12px;
+      }
+    }
+
+    mat-divider {
+      margin: 10px 0 5px 0;
+    }
+  }
+}

--- a/frontend/src/app/view/dashboard/plant-list.component.spec.ts
+++ b/frontend/src/app/view/dashboard/plant-list.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlantListComponent } from './plant-list.component';
+
+describe('PlantListComponent', () => {
+  let component: PlantListComponent;
+  let fixture: ComponentFixture<PlantListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PlantListComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PlantListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/view/dashboard/plant-list.component.ts
+++ b/frontend/src/app/view/dashboard/plant-list.component.ts
@@ -1,0 +1,18 @@
+import {Component, Input} from '@angular/core';
+import {MatCardModule} from '@angular/material/card';
+import {MatChipsModule} from '@angular/material/chips';
+import {MatDividerModule} from '@angular/material/divider';
+import {MatButtonModule} from '@angular/material/button';
+import {DatePipe, UpperCasePipe} from '@angular/common';
+import {PlantWithLastEnvironmentalMeasurement} from '../../client';
+
+@Component({
+  selector: 'app-plant-list',
+  standalone: true,
+  imports: [MatCardModule, MatChipsModule, MatDividerModule, MatButtonModule, DatePipe, UpperCasePipe],
+  templateUrl: './plant-list.component.html',
+  styleUrl: './plant-list.component.scss'
+})
+export class PlantListComponent {
+  @Input() plants: PlantWithLastEnvironmentalMeasurement[] = [];
+}


### PR DESCRIPTION
## Summary
- show plants information directly from the dashboard
- add a statistics widget with total number of plants
- layout dashboard with new components

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fb1fbcfb083208125666d44447199